### PR TITLE
fix: 使用人类可读的格式化时间代替原有的时间戳

### DIFF
--- a/bili-hardcore/tools/LLM/deepseek.py
+++ b/bili-hardcore/tools/LLM/deepseek.py
@@ -1,7 +1,7 @@
 import requests
 from typing import Dict, Any, Optional
 from config.config import PROMPT, API_KEY_DEEPSEEK
-from time import time
+from datetime import datetime
 
 class DeepSeekAPI:
     def __init__(self):
@@ -17,12 +17,14 @@ class DeepSeekAPI:
             "Authorization": f"Bearer {self.api_key}"
         }
         
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        
         data = {
             "model": self.model,
             "messages": [
                 {
                     "role": "user",
-                    "content": PROMPT.format(time(), question)
+                    "content": PROMPT.format(current_time, question)
                 }
             ]
         }

--- a/bili-hardcore/tools/LLM/gemini.py
+++ b/bili-hardcore/tools/LLM/gemini.py
@@ -1,7 +1,8 @@
 import requests
 from typing import Dict, Any, Optional
 from config.config import PROMPT,API_KEY_GEMINI
-from time import time,sleep
+from datetime import datetime
+from time import sleep
 
 
 class GeminiAPI:
@@ -17,12 +18,14 @@ class GeminiAPI:
             "Content-Type": "application/json"
         }
         
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        
         data = {
             "contents": [
                 {
                     "parts": [
                         {
-                            "text": PROMPT.format(time(), question)
+                            "text": PROMPT.format(current_time, question)
                         }
                     ]
                 }

--- a/bili-hardcore/tools/LLM/openai.py
+++ b/bili-hardcore/tools/LLM/openai.py
@@ -1,7 +1,7 @@
 import requests
 from typing import Dict, Any, Optional
 from config.config import PROMPT, API_KEY_OPENAI, BASE_URL_OPENAI,MODEL_OPENAI
-from time import time
+from datetime import datetime
 
 class OpenAIAPI:
     def __init__(self, base_url: str = None, model: str = None, api_key: str = None):
@@ -20,12 +20,14 @@ class OpenAIAPI:
             "Authorization": f"Bearer {self.api_key}"
         }
         
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        
         data = {
             "model": self.model,
             "messages": [
                 {
                     "role": "user",
-                    "content": PROMPT.format(time(), question)
+                    "content": PROMPT.format(current_time, question)
                 }
             ]
         }


### PR DESCRIPTION
在原`bili-hardcore/tools/LLM/deepseek.py` `bili-hardcore/tools/LLM/gemini.py` `bili-hardcore/tools/LLM/openai.py`中使用`time()`传递当前时间，但是Python的该函数返回的是时间戳，LLM/人类不可读。

使用`datetime.now().strftime("%Y-%m-%d %H:%M:%S")`格式化为LLM/人类可读的字符串。

```shell
Python 3.13.2 (main, Feb  4 2025, 14:51:09) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from time import time
... from datetime import datetime
... 
>>> time()
1744166742.375712
>>> datetime.now().strftime("%Y-%m-%d %H:%M:%S")
'2025-04-09 10:45:46'
>>> 
```